### PR TITLE
Add "quote" prop to Facebook button

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Basic usage from svelte looks like this:
 <Vk class="share-button" {title} {url} />
 <WhatsApp class="share-button" text="{title} {url}" />
 <Xing class="share-button" {title} {url} />
-<Facebook class="share-button" {url} />
+<Facebook class="share-button" quote="{title}" {url} />
 <Twitter class="share-button" text="{title}" {url} hashtags="github,svelte" via="username" related="other,users" />
 ```
 

--- a/src/Facebook.svelte
+++ b/src/Facebook.svelte
@@ -1,4 +1,5 @@
 <script>
+  export let quote;
   export let url;
   export let ariaLabel = 'Share on Facebook';
   let classes = '';
@@ -8,7 +9,7 @@
   import ShareButton from './ShareButton.svelte';
   let href;
   
-  $: href = encodeURI(`https://facebook.com/sharer/sharer.php?u=${url}`);
+  $: href = encodeURI(`https://facebook.com/sharer/sharer.php?u=${url}&quote=${quote}`);
 </script>
 
 <style>


### PR DESCRIPTION
Implements #50 

Called the prop `quote` to keep it consistent with the query param in the FB url.